### PR TITLE
Add new boards

### DIFF
--- a/src/components/boards.ts
+++ b/src/components/boards.ts
@@ -5,7 +5,7 @@ export const BoardsList = Object.freeze([
     field_pid: 67,
     adc_resolution: 10,
     channel_count: 6,
-    sampling_rate: 250,
+    sampling_rate: 500,
     serial_timeout: 2000,
     baud_Rate: 230400
   },
@@ -20,8 +20,28 @@ export const BoardsList = Object.freeze([
     baud_Rate: 230400
   },
   {
+    chords_id: "MEGA-2560-CLONE",
+    device_name: "MEGA 2560 CLONE",
+    field_pid: 29987,
+    adc_resolution: 10,
+    channel_count: 16,
+    sampling_rate: 250,
+    serial_timeout: 2000,
+    baud_Rate: 115200
+  },
+  {
+    chords_id: "MEGA-2560-CLONE",
+    device_name: "MEGA 2560 CLONE",
+    field_pid: 32832,
+    adc_resolution: 10,
+    channel_count: 16,
+    sampling_rate: 250,
+    serial_timeout: 2000,
+    baud_Rate: 115200
+  },
+  {
     chords_id: "NANO-CLONE",
-    device_name: "Arduino Nano Clone",
+    device_name: "Nano Clone",
     field_pid: 29987,
     adc_resolution: 10,
     channel_count: 8,
@@ -31,7 +51,7 @@ export const BoardsList = Object.freeze([
   },
   {
     chords_id: "NANO-CLONE",
-    device_name: "Arduino Nano Clone",
+    device_name: "Nano Clone",
     field_pid: 32832,
     adc_resolution: 10,
     channel_count: 8,
@@ -45,7 +65,7 @@ export const BoardsList = Object.freeze([
     field_pid: 579,
     adc_resolution: 10,
     channel_count: 6,
-    sampling_rate: 250,
+    sampling_rate: 500,
     serial_timeout: 2000,
     baud_Rate: 230400
   },

--- a/src/components/boards.ts
+++ b/src/components/boards.ts
@@ -5,9 +5,9 @@ export const BoardsList = Object.freeze([
     field_pid: 67,
     adc_resolution: 10,
     channel_count: 6,
-    sampling_rate: 500,
+    sampling_rate: 250,
     serial_timeout: 2000,
-    baud_Rate: 230400
+    baud_Rate: 115200
   },
   {
     chords_id: "MEGA-2560-R3",
@@ -15,9 +15,9 @@ export const BoardsList = Object.freeze([
     field_pid: 66,
     adc_resolution: 10,
     channel_count: 16,
-    sampling_rate: 500,
+    sampling_rate: 250,
     serial_timeout: 2000,
-    baud_Rate: 230400
+    baud_Rate: 115200
   },
   {
     chords_id: "MEGA-2560-CLONE",
@@ -35,6 +35,16 @@ export const BoardsList = Object.freeze([
     field_pid: 32832,
     adc_resolution: 10,
     channel_count: 16,
+    sampling_rate: 250,
+    serial_timeout: 2000,
+    baud_Rate: 115200
+  },
+  {
+    chords_id: "NANO-CLASSIC",
+    device_name: "Nano Classic",
+    field_pid: 24577,
+    adc_resolution: 10,
+    channel_count: 8,
     sampling_rate: 250,
     serial_timeout: 2000,
     baud_Rate: 115200
@@ -65,9 +75,9 @@ export const BoardsList = Object.freeze([
     field_pid: 579,
     adc_resolution: 10,
     channel_count: 6,
-    sampling_rate: 500,
+    sampling_rate: 250,
     serial_timeout: 2000,
-    baud_Rate: 230400
+    baud_Rate: 115200
   },
   {
     chords_id: "UNO-R4",

--- a/src/components/boards.ts
+++ b/src/components/boards.ts
@@ -10,6 +10,16 @@ export const BoardsList = Object.freeze([
     baud_Rate: 230400
   },
   {
+    chords_id: "MEGA-2560-R3",
+    device_name: "Arduino MEGA 2560 R3",
+    field_pid: 66,
+    adc_resolution: 10,
+    channel_count: 16,
+    sampling_rate: 500,
+    serial_timeout: 2000,
+    baud_Rate: 230400
+  },
+  {
     chords_id: "NANO-CLONE",
     device_name: "Arduino Nano Clone",
     field_pid: 29987,
@@ -95,6 +105,26 @@ export const BoardsList = Object.freeze([
     field_pid: 614,
     adc_resolution: 16,
     channel_count: 6,
+    sampling_rate: 500,
+    serial_timeout: 100,
+    baud_Rate: 230400
+  },
+  {
+    chords_id: "STM32G4-CORE-BOARD",
+    device_name: "STM32G4 Core Board",
+    field_pid: 22336,
+    adc_resolution: 12,
+    channel_count: 16,
+    sampling_rate: 500,
+    serial_timeout: 100,
+    baud_Rate: 230400
+  },
+  {
+    chords_id: "STM32F4-BLACK-PILL",
+    device_name: "STM32F4 Black Pill",
+    field_pid: 22336,
+    adc_resolution: 12,
+    channel_count: 8,
     sampling_rate: 500,
     serial_timeout: 100,
     baud_Rate: 230400


### PR DESCRIPTION
I have added three boards information:
1. STM32F4 Black Pill
2. STM32G4 Core Board
3. Arduino Mega 2560 R3

Arduino firmware is available here: https://github.com/upsidedownlabs/Chords-Arduino-Firmware

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added support for five new development boards:
		- Arduino MEGA 2560 R3
		- MEGA 2560 CLONE (two variants)
		- Nano Classic
		- STM32G4 Core Board
		- STM32F4 Black Pill
	- Expanded device compatibility with updated configurations for existing boards.
	- Enhanced baud rates for "Arduino UNO R3" and "Genuino UNO" from 230400 to 115200.
	- Updated device name for "Arduino Nano Clone" to "Nano Clone".
<!-- end of auto-generated comment: release notes by coderabbit.ai -->